### PR TITLE
DEVOPS-2604: Making custom change in TF provider

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!---
+Provide a general summary of your changes in the Title above
+-->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
+<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] Feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Refactoring (no functional changes, no api changes, formatting, renaming)
+- [ ] Other (please describe):
+
+## Pull request checklist
+<!--- Go over all the following points, and make sure you didn't miss anything important. -->
+- The commit message includes all information necessary for the reader to find out what is this change about
+- Documentation has been updated accordingly (if appropriate)
+- Any dependent changes have been merged and/or published
+
+## Changes in behavior
+- What is the current behavior?
+<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
+- What is the new behavior?
+<!-- Please describe the behavior or changes that are being added by this PR. -->
+- What steps are necessary for breaking change?
+<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications. -->
+
+## Other information
+<!-- Any other information that is important to this PR not covered earlier. -->

--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -60,7 +60,7 @@ func isDefault(tc *sarama.ConfigEntry, version int) bool {
 	if version == 0 {
 		return tc.Default
 	}
-	return tc.Source == sarama.SourceDefault || tc.Source == sarama.SourceStaticBroker
+	return (tc.Source == sarama.SourceDefault || tc.Source == sarama.SourceStaticBroker) && tc.Name != "min.insync.replicas"
 }
 
 func metaToTopic(d *schema.ResourceData, meta interface{}) Topic {


### PR DESCRIPTION
DEVOPS-2604: It looks like that MM2 overwrites topics permission and all topcis are marked us

min.insync.replicas=2 sensitive=false synonyms={STATIC_BROKER_CONFIG:min.insync.replicas=2, DEFAULT_CONFIG:min.insync.replicas=1}
it removes DYNAMIC_TOPIC_CONFIG (during replication mm2)
min.insync.replicas=2 sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:min.insync.replicas=2, STATIC_BROKER_CONFIG:min.insync.replicas=2, DEFAULT_CONFIG:min.insync.replicas=1}



